### PR TITLE
Update to Magellan 2.1 and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:latest
 
-ENV MAGELLAN_VERSION 1.1.1
+ENV MAGELLAN_VERSION 2.1
 
 RUN pip install https://github.com/RIPE-NCC/ripe-atlas-tools/archive/v${MAGELLAN_VERSION}.zip
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Magellan is the official command-line client for RIPE Atlas.
 
 > [Magellan Documentation](https://ripe-atlas-tools.readthedocs.org/)
 
+# How to build this image
+
+If you want to build the image locally you can do this by running the following command.
+
+```console
+$ docker build -t insready/magellan .
+```
+
+
 # How to use this image
 
 View a basic report for a public measurement:


### PR DESCRIPTION
Updated to Magellan 2.1 and added a small documentation snippet on how to build the image locally